### PR TITLE
Badge changes

### DIFF
--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -1,6 +1,8 @@
 name: .NET Core
 
 on: 
+  pull_request:
+    branches: master
   push:
     branches-ignore: master
 

--- a/QrCodeApiApp/QrCodeApiApp.csproj
+++ b/QrCodeApiApp/QrCodeApiApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://joelbyford.visualstudio.com/QrCodeApiApp/_apis/build/status/niematron.QrCodeApiApp?branchName=master)](https://joelbyford.visualstudio.com/QrCodeApiApp/_build/latest?definitionId=6&branchName=master)
+![](https://github.com/joelbyford/QrCodeApiApp/workflows/.NET%20Core%20-%20Release%20from%20Master/badge.svg)
 
 # QrCodeApiApp
 A simple QRCode Encoder API in .NET Core using ZXing and published as an Azure API App.  "Leveraging" much of the work others have performed ahead of me.  Special thanks to GitHub Contributors Including:


### PR DESCRIPTION
Updating to .net core 2.2 and replacing Azure DevOps build badge with the GitHub Actions badge.  Also ensuring build (non-master) is run against any forks by adding on:pull-request trigger to .yml.