### PR TITLE
Building debug and publishing to staging environment

### DIFF
--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -1,4 +1,4 @@
-name: .NET Core Debug in Staging
+name: .NET Core - Debug in Staging
 
 on: 
   pull_request:

--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches-ignore: master
 
-jenv:
+env:
   AZURE_WEBAPP_NAME: qrcode-api-app    # set this to your application's name
 
 jobs:

--- a/.github/workflows/dotnetcore-build.yml
+++ b/.github/workflows/dotnetcore-build.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: .NET Core Debug in Staging
 
 on: 
   pull_request:


### PR DESCRIPTION
Previously was building release only and was not publishing resulting artifact anywhere.  Now will build debug and publish into a staging environment (using a slot-specific publish profile versus slot deployment).