### PR TITLE
Merge Dependabot Recommendations

### DIFF
--- a/QrCodeApiApp/QrCodeApiApp.csproj
+++ b/QrCodeApiApp/QrCodeApiApp.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ZXing.Net" Version="0.16.5" />
   </ItemGroup>

--- a/QrCodeApiApp/QrCodeApiApp.csproj
+++ b/QrCodeApiApp/QrCodeApiApp.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="ZXing.Net" Version="0.16.5" />
+    <PackageReference Include="ZXing.Net" Version="0.16.6" />
   </ItemGroup>
 
 </Project>

--- a/QrCodeApiApp/QrCodeApiApp.csproj
+++ b/QrCodeApiApp/QrCodeApiApp.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ZXing.Net" Version="0.16.5" />


### PR DESCRIPTION
Manually merging dependabot recommendations as it required a downgrade of Razor.Design to 2.1.1 (from 2.2.0). 

1. Upgrade `System.Drawing.Common 4.7.0` to `5.0.0`
2. Upgrade `ZXing.Net 0.16.5` to `0.16.6`
3. Downgrade `Microsoft.AspNetCore.Razor.Design 2.2.0` to `2.1.1`