### PR TITLE
bumping github actions for node12->16

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.5
+      uses: actions/checkout@v2.5.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2.5
+      uses: actions/checkout@v2.5.0
 
     - name: Setup dotnet 6.0.x
       uses: actions/setup-dotnet@v1
@@ -44,7 +44,7 @@ jobs:
     needs: build
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2.5
+        uses: actions/checkout@v2.5.0
 
       - name: Setup Python
         uses: actions/setup-python@v4.3.0

--- a/.github/workflows/main-pr.yml
+++ b/.github/workflows/main-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.5
 
     - name: Setup dotnet 6.0.x
       uses: actions/setup-dotnet@v1
@@ -44,10 +44,10 @@ jobs:
     needs: build
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5
 
       - name: Setup Python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.3.0
 
       - name: Install pytest
         run: |

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.5
 
     - name: Setup dotnet 6.0.x
       uses: actions/setup-dotnet@v1
@@ -49,10 +49,10 @@ jobs:
     needs: build
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5
         
       - name: Setup Python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v4.3.0
 
       - name: Install pytest
         run: |

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2.5
+      uses: actions/checkout@v2.5.0
 
     - name: Setup dotnet 6.0.x
       uses: actions/setup-dotnet@v1
@@ -49,7 +49,7 @@ jobs:
     needs: build
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2.5
+        uses: actions/checkout@v2.5.0
         
       - name: Setup Python
         uses: actions/setup-python@v4.3.0

--- a/.github/workflows/manual-openId.yml
+++ b/.github/workflows/manual-openId.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2.5
+      - uses: actions/checkout@v2.5.0
       
       # Installs the CLI-beta in a python venv
       - name: Installing CLI-beta for OpenID Connect

--- a/.github/workflows/manual-openId.yml
+++ b/.github/workflows/manual-openId.yml
@@ -20,7 +20,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5
       
       # Installs the CLI-beta in a python venv
       - name: Installing CLI-beta for OpenID Connect


### PR DESCRIPTION
Bumping GitHub Actions to the latest version to address node12 deprecation warning.  